### PR TITLE
SoloRecipeView renders based on clicked tile

### DIFF
--- a/dist/styles/SoloRecipeView.css
+++ b/dist/styles/SoloRecipeView.css
@@ -2,6 +2,7 @@
   display: flex;
   width: 100%;
   flex-direction: column;
+  margin-top: 20px;
   align-items: center;
 }
 
@@ -117,6 +118,7 @@
   display: flex;
   flex-direction: column;
   width: 20%;
+  height: max-content;
   padding: 10px;
   margin: 30px 20px;
   border-radius: 15px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,13 +26,15 @@ class App extends React.Component {
       },
       favorites: [],
       currentView: 'home',
-      showLogin: false
+      showLogin: false,
+      currentRecipeId: ''
     }
     this.captureUser = this.captureUser.bind(this);
     this.captureFavorites = this.captureFavorites.bind(this);
     this.captureNavigation = this.captureNavigation.bind(this);
     this.handleClose = this.handleClose.bind(this);
     this.openLogin = this.openLogin.bind(this);
+    this.captureRecipeId = this.captureRecipeId.bind(this);
   }
 
   captureUser({ name, email, pantry }) {
@@ -54,6 +56,10 @@ class App extends React.Component {
       this.setState({ currentView: newView });
   }
 
+  captureRecipeId(recipeId) {
+    this.setState({ currentRecipeId: recipeId});
+  }
+
   openLogin() {
     this.setState({showLogin: true});
   }
@@ -63,7 +69,7 @@ class App extends React.Component {
   }
 
   render() {
-    const { user, favorites, currentView, showLogin } = this.state;
+    const { user, favorites, currentView, showLogin, currentRecipeId } = this.state;
     return (
       <div className="main">
         <div className="navdiv">
@@ -80,7 +86,7 @@ class App extends React.Component {
         </SignInModal>
         ) : ''}
 
-        {this.state.currentView === 'home' && <HomeFeedView captureNavigation = {this.captureNavigation}/>}
+        {this.state.currentView === 'home' && <HomeFeedView captureNavigation = {this.captureNavigation} captureRecipeId={this.captureRecipeId}/>}
         {this.state.currentView === 'favorites' && <FavoriteView/>}
         {currentView === 'explore' ? (
           <SearchResultsView
@@ -91,7 +97,7 @@ class App extends React.Component {
             captureNavigation={this.captureNavigation}
           />
         ) : ''}
-        {currentView === 'recipe' && <SoloRecipeView captureNavigation = {this.captureNavigation}/>}
+        {currentView === 'recipe' && <SoloRecipeView captureNavigation = {this.captureNavigation} recipeId={currentRecipeId}/>}
 
         {currentView === 'profile' ? (<ProfileView openLogin={this.openLogin} captureNavigation={this.captureNavigation} />) : ''}
 

--- a/src/components/HomeFeedView.jsx
+++ b/src/components/HomeFeedView.jsx
@@ -6,7 +6,7 @@ import upArrow from '../../dist/resources/homeView/up-arrow.png';
 import { API_ADDR } from '../config';
 
 
-const HomeFeedView = ({captureNavigation}) => {
+const HomeFeedView = ({captureNavigation, captureRecipeId}) => {
   const [sortDisplay, updateSortDisplay] = useState(false);
   const [sortOption, updateSortOption] = useState('mostPopular');
   const [sortedData, updateSortedData] = useState([]);
@@ -90,7 +90,7 @@ const HomeFeedView = ({captureNavigation}) => {
         <div id="receipeBox">
           {sortedData[0] && (
             sortedData.map((recipe) => {
-              return <RecipeTile key={recipe.id} recipe={recipe} captureNavigation={captureNavigation}/>
+              return <RecipeTile key={recipe.id} recipe={recipe} captureNavigation={captureNavigation} captureRecipeId={captureRecipeId}/>
             })
           )}
         </div>

--- a/src/components/RecipeTile.jsx
+++ b/src/components/RecipeTile.jsx
@@ -7,15 +7,21 @@ import cost from '../../dist/resources/RecipeTile/cost.png';
 import emptyStar from '../../dist/resources/RecipeTile/emptyStar.png';
 import fullStar from '../../dist/resources/RecipeTile/fullStar.png';
 
-const RecipeTile = ({ captureNavigation, recipe }) => {
+const RecipeTile = ({ captureNavigation, recipe, captureRecipeId }) => {
 
   return (
     <div className="recipeTileContainer">
-      <img className="recipeTileImage" src={recipe.image} onClick={(e) => captureNavigation('recipe')} />
+      <img className="recipeTileImage" src={recipe.image} onClick={(e) => {
+        captureRecipeId(recipe.id);
+        captureNavigation('recipe');
+        }} />
 
       <div className="recipeTileInformationContainer">
         <div className="recipeTileHeader">
-          <div className="recipeTileName" onClick={(e) => captureNavigation('recipe')}>{recipe.title}</div>
+          <div className="recipeTileName" onClick={(e) => {
+            captureRecipeId(recipe.id);
+            captureNavigation('recipe')
+          }}>{recipe.title}</div>
           <img className="recipeTileFavoriteIcon" src={emptyStar} />
         </div>
 

--- a/src/components/SoloRecipeView.jsx
+++ b/src/components/SoloRecipeView.jsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { API_ADDR } from '../config';
 import parse from 'html-react-parser';
 
 import time from '../../dist/resources/SoloRecipeView/time.png';
@@ -10,20 +12,22 @@ import check from '../../dist/resources/SoloRecipeView/check.png';
 import emptyStar from '../../dist/resources/SoloRecipeView/emptyStar.png';
 import fullStar from '../../dist/resources/SoloRecipeView/fullStar.png';
 
-const SoloRecipeView = ({ captureNavigation }) => {
-
+const SoloRecipeView = ({ captureNavigation, recipeId }) => {
+  const [recipe, updateRecipe] = useState('');
   const pantry = [1, 2, 3, 4, 45];
-  const recipe = {"id":37,"title":"Flounder With Spring Artichoke Hearts & Capers","likes":1,"summary":"Flounder With Spring Artichoke Hearts & Capers is a <b>gluten free, primal, and ketogenic</b> main course. This recipe serves 3 and costs $3.26 per serving. One serving contains <b>355 calories</b>, <b>22g of protein</b>, and <b>25g of fat</b>. 1 person were impressed by this recipe. It will be a hit at your <b>Spring</b> event. A mixture of wine, butter, capers, and a handful of other ingredients are all it takes to make this recipe so scrumptious. To use up the butter you could follow this main course with the <a href=\"https://spoonacular.com/recipes/cinnamon-butter-cake-60334\">Cinnamon Butter Cake</a> as a dessert. From preparation to the plate, this recipe takes about <b>45 minutes</b>. All things considered, we decided this recipe <b>deserves a spoonacular score of 41%</b>. This score is solid. Similar recipes include <a href=\"https://spoonacular.com/recipes/eggs-in-purgatory-with-artichoke-hearts-potatoes-and-capers-109240\">Eggs in Purgatory with Artichoke Hearts, Potatoes and Capers</a>, <a href=\"https://spoonacular.com/recipes/eggs-in-purgatory-with-artichoke-hearts-potatoes-and-capers-29922\">Eggs In Purgatory With Artichoke Hearts, Potatoes, And Capers</a>, and <a href=\"https://spoonacular.com/recipes/potato-salad-with-capers-kalamata-olives-and-artichoke-hearts-109009\">Potato Salad With Capers, Kalamatan Olives and Artichoke Hearts</a>.","time":45,"servings":3,"image":"https://spoonacular.com/recipeImages/1388-556x370.jpg","price":327.54,"source_name":"One Hungry Mama","source_url":"http://onehungrymama.com/2010/05/recipe-flounder-with-spring-artichokes-hearts-capers/","ingredients":[{"id":168,"name":"marinated artichokes","category":"Canned and Jarred","frequency":45},{"id":45,"name":"butter","category":"Milk, Eggs, Other Dairy","frequency":1914},{"id":37,"name":"capers","category":"Canned and Jarred","frequency":121},{"id":169,"name":"chicken broth","category":"Canned and Jarred","frequency":389},{"id":170,"name":"flounder fillets","category":"Seafood","frequency":11},{"id":33,"name":"lemon juice","category":"Produce","frequency":1202},{"id":4,"name":"olive oil","category":"Oil, Vinegar, Salad Dressing","frequency":2737},{"id":49,"name":"onion","category":"Produce","frequency":2464},{"id":77,"name":"dry white wine","category":"Alcoholic Beverages","frequency":347}],"sections":1,"instructions": [
-    {
-      "name": "",
-      "steps": [
-        "Make croutons: Preheat oven to 375 degrees.",
-        "Place bread on a rimmed baking sheet.",
-        "Drizzle with 2 tablespoons of the oil, and season with salt and pepper; toss to coat.",
-        "Bake, tossing occasionally, until golden, 12 to 15 minutes; remove from oven; and let cool."
-      ]
-    }
-  ],"tags":[{"id":14,"name":"lunch","category":"dish","frequency":4274},{"id":15,"name":"main course","category":"dish","frequency":4274},{"id":16,"name":"main dish","category":"dish","frequency":4274},{"id":17,"name":"dinner","category":"dish","frequency":4274},{"id":13,"name":"gluten free","category":"diets","frequency":5393},{"id":19,"name":"primal","category":"diets","frequency":937}],"tag_ids":[14,15,16,17,13,19],"ingredient_ids":[168,45,37,169,170,33,4,49,77],"createdAt":"2022-01-31T03:16:59.614Z","updatedAt":"2022-01-31T03:17:12.794Z"}
+  const getRecipe = (id) => {
+    axios.get(`${API_ADDR}/recipes/${id}`)
+      .then ((res) => {
+        updateRecipe(res.data);
+      })
+  }
+  useEffect(() => {
+    getRecipe(recipeId);
+  }, [recipeId])
+
+  if (!recipe) {
+    return <div>Still Loading...</div>
+  }
 
   return (
     <div className="soloRecipeViewContainer">
@@ -33,7 +37,7 @@ const SoloRecipeView = ({ captureNavigation }) => {
         <img className="favoriteButton" src={emptyStar}/>
       </div>
       <div className="recipeInformation">
-        <img className="recipeImage" src="https://spoonacular.com/recipeImages/579247-556x370.jpg"/>
+        <img className="recipeImage" src={recipe.image}/>
         <div className="recipeStatsContainer">
           <div className="recipeStats">
             <img className="recipeStatIcon" src={time}/>


### PR DESCRIPTION
@Heine574 @lbc1013 @winstonthep 

- Implemented SoloRecipeView rendering based on clicked RecipeTile
- Added top margin to SoloRecipeView to space it from the navbar
- Fixed Ingredient List container sometimes being larger than needed if the recipe instructions were long.
- @lbc1013 @Heine574 for Favorites/Search View, the RecipeTile component takes 3 props: 
``` <RecipeTile recipe={recipe} captureNavigation={captureNavigation} captureRecipeId={captureRecipeId}/> ```
- recipe provides the recipeTile with the recipe information to render
- captureNavigation enables the RecipeTile to change to the SoloRecipeView when clicked.
- captureRecipeId enables the RecipeTile to send the clicked recipe id to App.jsx so that SoloRecipeView can retrieve it and render the selected recipe.