### PR TITLE
implemented mobile view for solo recipe

### DIFF
--- a/dist/styles/HomeView.css
+++ b/dist/styles/HomeView.css
@@ -141,5 +141,6 @@
 
   #receipeBox {
     width: 100%;
+    margin-bottom: 10%;
   }
 }

--- a/dist/styles/HomeView.css
+++ b/dist/styles/HomeView.css
@@ -135,7 +135,7 @@
 }
 
 @media only screen and (max-device-width: 800px) {
-  #homeView {
+  #homeTopView {
     margin-top: 0;
   }
 

--- a/dist/styles/HomeView.css
+++ b/dist/styles/HomeView.css
@@ -140,6 +140,6 @@
   }
 
   #receipeBox {
-    width: 90%;
+    width: 100%;
   }
 }

--- a/dist/styles/RecipeTile.css
+++ b/dist/styles/RecipeTile.css
@@ -78,7 +78,7 @@
   font-size: 100%;
   padding: 5px 10px;
   border-radius: 25px;
-  box-shadow: 0px 0px 1x 1px rgba(56, 55, 55, 0.199);
+  box-shadow: 0px 0px 1px 1px rgba(56, 55, 55, 0.199);
 }
 
 .dietsTag {
@@ -99,7 +99,7 @@
   }
 
   .recipeTileFavoriteIcon {
-    height: 60%;
+    height: 24px;
   }
   .recipeTileImage {
     width: 30%;

--- a/dist/styles/RecipeTile.css
+++ b/dist/styles/RecipeTile.css
@@ -24,7 +24,7 @@
 .recipeTileHeader {
   display: flex;
   align-items: center;
-  font-size: 180%;
+  font-size: 1.8em;
 }
 
 .recipeTileName {
@@ -76,7 +76,7 @@
   color: black;
   height: max-content;
   margin-right: 15px;
-  font-size: 100%;
+  font-size: 1em;
   padding: 5px 10px;
   border-radius: 25px;
   box-shadow: 0px 0px 1px 1px rgba(56, 55, 55, 0.199);
@@ -96,7 +96,7 @@
 
 @media only screen and (max-device-width: 800px) {
   .recipeTileContainer {
-    font-size: 60%;
+    font-size: 0.7em;
   }
 
   .recipeTileFavoriteIcon {
@@ -114,7 +114,7 @@
   }
 
   .recipeTileStats {
-    font-size: 150%;
+    font-size: 1.5em;
   }
 
   .recipeTileTags {

--- a/dist/styles/RecipeTile.css
+++ b/dist/styles/RecipeTile.css
@@ -28,6 +28,7 @@
 }
 
 .recipeTileName {
+  width: 90%;
   margin-right: 30px;
   cursor: pointer;
 }

--- a/dist/styles/SoloRecipeView.css
+++ b/dist/styles/SoloRecipeView.css
@@ -62,7 +62,7 @@
 }
 
 .recipeTagsContainer {
-  color: white;
+  color: rgb(0, 0, 0);
   display: flex;
   flex-direction: column;
   font-size: 110%;
@@ -74,11 +74,12 @@
 }
 
 .dietTagsContainer div {
-  background: rgb(8, 129, 0);
+  background: #ffeec7;
+  text-align: center;
   margin-right: 10px;
   padding: 5px 10px;
-  border-radius: 10px;
-  box-shadow: 0px 0px 2px 1px rgba(0,0,0,0.6);
+  border-radius: 25px;
+  box-shadow: 0px 0px 1px 1px rgba(56, 55, 55, 0.199);
 }
 
 .cuisineTagsContainer {
@@ -87,11 +88,12 @@
 }
 
 .cuisineTagsContainer div {
-  background: rgb(159, 3, 3);
+  background: #DFEFFF;
+  text-align: center;
   margin-right: 10px;
   padding: 5px 10px;
-  border-radius: 10px;
-  box-shadow: 0px 0px 2px 1px rgba(0,0,0,0.6);
+  border-radius: 25px;
+  box-shadow: 0px 0px 1px 1px rgba(56, 55, 55, 0.199);
 }
 
 .dishTagsContainer {
@@ -100,17 +102,19 @@
 }
 
 .dishTagsContainer div {
-  background: rgb(86, 0, 201);
+  background: #E4DCFF;
+  text-align: center;
   margin-right: 10px;
   padding: 5px 10px;
-  border-radius: 10px;
-  box-shadow: 0px 0px 2px 1px rgba(0,0,0,0.6);
+  border-radius: 25px;
+  box-shadow: 0px 0px 1px 1px rgba(56, 55, 55, 0.199);
 }
 
 .recipeDescription {
   width: 80%;
   margin: 30px 10px;
   font-size: 110%;
+  text-align: justify;
 }
 
 .recipeDescription a {
@@ -170,4 +174,38 @@
 .recipeInstructions div {
   margin-bottom: 30px;
   font-size: 110%;
+}
+
+@media only screen and (max-device-width: 800px) {
+  .soloRecipeViewContainer {
+    margin: 0;
+  }
+
+  .recipeViewHeader {
+    flex-direction: column;
+    width: 90%;
+    text-align: center;
+  }
+
+  .mobileBackFavorite {
+    display: flex;
+    justify-content: space-between;
+  }
+  .recipeImage {
+    max-height: 259px;
+    max-width: 390px;
+  }
+
+  .recipeInformation {
+    flex-direction: column;
+  }
+
+  .recipeBody {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .recipeIngredientList {
+    width: 100%;
+  }
 }

--- a/dist/styles/SoloRecipeView.css
+++ b/dist/styles/SoloRecipeView.css
@@ -2,7 +2,7 @@
   display: flex;
   width: 100%;
   flex-direction: column;
-  margin-top: 50px;
+  margin-top: 70px;
   align-items: center;
 }
 
@@ -11,7 +11,7 @@
   justify-content: space-between;
   width: 60%;
   margin: 30px 10px;
-  font-size: 300%;
+  font-size: 3em;
 }
 
 .backButton {
@@ -54,7 +54,7 @@
   display: flex;
   align-items: center;
   margin: 10px 0;
-  font-size: 150%;
+  font-size: 1.5em;
 }
 
 .recipeStats div {
@@ -65,7 +65,7 @@
   color: rgb(0, 0, 0);
   display: flex;
   flex-direction: column;
-  font-size: 110%;
+  font-size: 1.1em;
 }
 
 .dietTagsContainer {
@@ -113,7 +113,7 @@
 .recipeDescription {
   width: 80%;
   margin: 30px 10px;
-  font-size: 110%;
+  font-size: 1.1em;
   text-align: justify;
 }
 
@@ -139,7 +139,7 @@
 
 .recipeIngredientList section {
   align-self: center;
-  font-size: 150%;
+  font-size: 1.5em;
   margin-bottom: 10px;
 }
 
@@ -149,7 +149,7 @@
 }
 
 .ingredientListEntry div {
-  font-size: 130%;
+  font-size: 1.3em;
 }
 
 .ingredientListEntry img {
@@ -167,13 +167,13 @@
 }
 
 .recipeInstructions section {
-  font-size: 200%;
+  font-size: 2em;
   margin-bottom: 10px;
 }
 
 .recipeInstructions div {
   margin-bottom: 30px;
-  font-size: 110%;
+  font-size: 1.1em;
 }
 
 @media only screen and (max-device-width: 800px) {

--- a/src/components/RecipeTile.jsx
+++ b/src/components/RecipeTile.jsx
@@ -44,7 +44,7 @@ const RecipeTile = ({ captureNavigation, recipe, captureRecipeId, favorites, cap
           </div>
           <img className="recipeTileCostIcon" src={cost} />
           <div className="recipeTileCost">
-            {window.innerWidth > 800 ? `$${numberWithCommas(Math.trunc(recipe.price))}/serving`: `$${numberWithCommas(Math.trunc(recipe.price))}`}
+            {window.innerWidth > 800 ? `$${numberWithCommas((Math.floor((recipe.price/100) * 100) / 100).toFixed(2))} / serving`: `$${numberWithCommas((Math.floor((recipe.price/100) * 100) / 100).toFixed(2))}`}
           </div>
           <img className="recipeTileRatingIcon" src={emptyHeart} />
           <div className="recipeTileRating">

--- a/src/components/RecipeTile.jsx
+++ b/src/components/RecipeTile.jsx
@@ -26,7 +26,7 @@ const RecipeTile = ({ captureNavigation, recipe, captureRecipeId, favorites, cap
         <div className="recipeTileHeader">
           <div
             className="recipeTileName"
-            style={{fontSize: recipe.title.length > 30 ? '70%':'100%'}}
+            style={{fontSize: recipe.title.length > 30 ? '80%':'100%'}}
             onClick={(e) => {
               captureRecipeId(recipe.id);
               captureNavigation("recipe");

--- a/src/components/SoloRecipeView.jsx
+++ b/src/components/SoloRecipeView.jsx
@@ -53,7 +53,7 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
           </div>
           <div className="recipeStats">
             <img className="recipeStatIcon" src={cost}/>
-            <div className="recipeStat">${Math.trunc(recipe.price)} per serving</div>
+            <div className="recipeStat">${numberWithCommas((Math.floor((recipe.price/100) * 100) / 100).toFixed(2))} per serving</div>
           </div>
           <div className="recipeStats">
             <img className="recipeStatIcon" src={fullHeart}/>

--- a/src/components/SoloRecipeView.jsx
+++ b/src/components/SoloRecipeView.jsx
@@ -22,6 +22,9 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
         updateRecipe(res.data);
       })
   }
+  const numberWithCommas = (x) => {
+    return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
   useEffect(() => {
     getRecipe(recipeId);
   }, [recipeId])
@@ -33,9 +36,13 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
   return (
     <div className="soloRecipeViewContainer">
       <div className="recipeViewHeader">
-        <img className="backButton" src={back} onClick={(e) => captureNavigation(previousView)}/>
+        {window.innerWidth <= 800 && <div className="mobileBackFavorite">
+          <img className="backButton" src={back} onClick={(e) => captureNavigation(previousView)}/>
+          <img className="favoriteButton" src={favorites.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/>
+        </div>}
+        {window.innerWidth > 800 && <img className="backButton" src={back} onClick={(e) => captureNavigation(previousView)}/>}
         <div className="recipeName">{recipe.title}</div>
-        <img className="favoriteButton" src={favorites.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/>
+        {window.innerWidth > 800 && <img className="favoriteButton" src={favorites.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/>}
       </div>
       <div className="recipeInformation">
         <img className="recipeImage" src={recipe.image}/>
@@ -50,7 +57,7 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
           </div>
           <div className="recipeStats">
             <img className="recipeStatIcon" src={fullHeart}/>
-            <div className="recipeStat">{recipe.likes} {recipe.likes > 1 ? 'users like':'user likes'} this recipe</div>
+            <div className="recipeStat">{numberWithCommas(recipe.likes)} {recipe.likes > 1 ? 'users like':'user likes'} this recipe</div>
           </div>
           <div className="recipeTagsContainer">
             <div className="dietTagsContainer">


### PR DESCRIPTION
@lbc1013 @winstonthep @Heine574 

- SoloRecipeView now renders properly on mobile devices
- Modified SoloRecipeView tags to match RecipeTiles
- SoloRecipeView 'likes' now have comma separator.
- Changed prices from cents to dollars everywhere.
- Removed homefeed top margin on mobile
- Added homefeed bottom margin on mobile so the tiles don't end up behind the navbar
- Aligned favorite icons on RecipeTiles mobile (before they were moving around a little based on recipe name length)
- Changed all font-sizes from % to em.
- Increased font-size of recipeTile mobile view.