### PR TITLE
Tile css changes

### DIFF
--- a/dist/styles/FavoriteView.css
+++ b/dist/styles/FavoriteView.css
@@ -11,3 +11,8 @@
   color: #E86D4D;
   font-weight: bold;
 }
+
+#favoriteList {
+  display: flex;
+  flex-direction: column;
+}

--- a/dist/styles/RecipeTile.css
+++ b/dist/styles/RecipeTile.css
@@ -11,13 +11,14 @@
   max-height: 185px;
   max-width: 278px;
   border-radius: 10px;
-  margin-right: 15px;
+  /* margin-right: 15px; */
   cursor: pointer;
 }
 
 .recipeTileInformationContainer {
   display: flex;
   width: 100%;
+  padding-left: 10px;
   flex-direction: column;
 }
 
@@ -102,6 +103,11 @@
   .recipeTileFavoriteIcon {
     height: 24px;
   }
+
+  .recipeTileInformationContainer {
+    width: 70%;
+  }
+
   .recipeTileImage {
     width: 30%;
     height: 100%;
@@ -114,7 +120,7 @@
   }
 
   .recipeTileStats {
-    font-size: 1.5em;
+    font-size: 1.4em;
   }
 
   .recipeTileTags {

--- a/dist/styles/RecipeTile.css
+++ b/dist/styles/RecipeTile.css
@@ -11,7 +11,6 @@
   max-height: 185px;
   max-width: 278px;
   border-radius: 10px;
-  /* margin-right: 15px; */
   cursor: pointer;
 }
 

--- a/dist/styles/SoloRecipeView.css
+++ b/dist/styles/SoloRecipeView.css
@@ -75,6 +75,7 @@
 
 .dietTagsContainer div {
   background: #ffeec7;
+  height: max-content;
   text-align: center;
   margin-right: 10px;
   padding: 5px 10px;
@@ -89,6 +90,7 @@
 
 .cuisineTagsContainer div {
   background: #DFEFFF;
+  height: max-content;
   text-align: center;
   margin-right: 10px;
   padding: 5px 10px;
@@ -103,6 +105,7 @@
 
 .dishTagsContainer div {
   background: #E4DCFF;
+  height: max-content;
   text-align: center;
   margin-right: 10px;
   padding: 5px 10px;

--- a/src/components/SoloRecipeView.jsx
+++ b/src/components/SoloRecipeView.jsx
@@ -38,7 +38,7 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
       <div className="recipeViewHeader">
         {window.innerWidth <= 800 && <div className="mobileBackFavorite">
           <img className="backButton" src={back} onClick={(e) => captureNavigation(previousView)}/>
-          <img className="favoriteButton" src={favorites.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/>
+          <img className="favoriteButton" src={JSON.stringify(favorites).includes(JSON.stringify(recipe)) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipe, true)}/>
         </div>}
         {window.innerWidth > 800 && <img className="backButton" src={back} onClick={(e) => captureNavigation(previousView)}/>}
         <div className="recipeName">{recipe.title}</div>


### PR DESCRIPTION
@lbc1013 @winstonthep @Heine574 

- Fixed favorite button on recipe tiles going out of the screen on small mobile devices
- Recipe tags will only resize if the tag length requires it, instead of every tag resizing when a single tag needs a larger sized tag space.
- Changed the favorite recipes tile container in favorites view to be flex and column so the recipe tiles images render in full size.