### PR TITLE
fixed info getting out of tiles in mobile view

### DIFF
--- a/dist/styles/HomeView.css
+++ b/dist/styles/HomeView.css
@@ -152,4 +152,8 @@
     width: 100%;
     margin-bottom: 10%;
   }
+
+  #sortedList {
+    width: 100%;
+  }
 }

--- a/dist/styles/RecipeTile.css
+++ b/dist/styles/RecipeTile.css
@@ -96,6 +96,7 @@
 
 @media only screen and (max-device-width: 800px) {
   .recipeTileContainer {
+    margin: 10px 0;
     font-size: 0.7em;
   }
 


### PR DESCRIPTION
@lbc1013 @winstonthep @Heine574 

- Increased the width of the recipeTiles parent container to use the whole screen in mobile view
- Removed side margins from the tiles in mobile view