### PR TITLE
same sized tile images on mobile

### DIFF
--- a/dist/styles/RecipeTile.css
+++ b/dist/styles/RecipeTile.css
@@ -110,7 +110,7 @@
 
   .recipeTileImage {
     width: 30%;
-    height: 100%;
+    height: 100px;
     object-fit: cover;
     align-self: center;
   }
@@ -121,6 +121,10 @@
 
   .recipeTileStats {
     font-size: 1.4em;
+  }
+
+  .recipeTileStats div {
+    margin-right: 10px;
   }
 
   .recipeTileTags {


### PR DESCRIPTION
@lbc1013 @winstonthep @Heine574 

- Recipe images are now equally sized in mobile view, regardless of tile size.
- Reduced the spacing between stats (time/price/likes) in mobile view