### PR TITLE
Favorites with user

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,57 +75,56 @@ class App extends React.Component {
 
   captureFavorites(recipeId = '', modify = false) {
     // Tweak for fast favorites rendering
-    let stringState = JSON.stringify(this.state.favorites);
-    let stringRecipe = JSON.stringify(recipeId);
-
-    if (modify) {
-      let action;
-      if (stringState.includes(stringRecipe)) {
-        action = 'remove';
-      } else {
-        action = 'add';
-      }
-      if (action === 'add') {
-        this.setState(prevState => ({favorites: [...JSON.parse(JSON.stringify(prevState.favorites)), recipeId]}), () => {
-        })
-      }
-
-      if (action === 'remove') {
-        this.setState(prevState => ({favorites: prevState.favorites.filter(recipe => JSON.stringify(recipe) !== JSON.stringify(recipeId))}))
-      }
-    } else {
-      return this.state.favorites;
-    }
+    // let stringState = JSON.stringify(this.state.favorites);
+    // let stringRecipe = JSON.stringify(recipeId);
 
     // if (modify) {
     //   let action;
-    //   if (this.state.favorites.includes(recipeId)) {
+    //   if (stringState.includes(stringRecipe)) {
     //     action = 'remove';
     //   } else {
     //     action = 'add';
     //   }
     //   if (action === 'add') {
-    //     this.setState(prevState => ({favorites: [...prevState.favorites, recipeId]}), () => {
+    //     this.setState(prevState => ({favorites: [...JSON.parse(JSON.stringify(prevState.favorites)), recipeId]}), () => {
     //     })
     //   }
 
     //   if (action === 'remove') {
-    //     this.setState(prevState => ({favorites: prevState.favorites.filter(id => id !== recipeId)}))
+    //     this.setState(prevState => ({favorites: prevState.favorites.filter(recipe => JSON.stringify(recipe) !== JSON.stringify(recipeId))}))
     //   }
-    //   // // Uncomment when userId works
-    //   // axios.get(`${API_ADDR}/users/${this.state.user.userId}/recipes/${recipeId}/${action}`)
-    //   // .then(res => {
-    //   //   this.setState({favorites: res.data});
-    //   // })
     // } else {
     //   return this.state.favorites;
-
-    //   // // Uncomment when userId works
-    //   // axios.get(`${API_ADDR}/users/${this.state.user.userId}/recipes`)
-    //   // .then(res => {
-    //   //   this.setState({favorites: res.data});
-    //   // })
     // }
+
+    if (!this.state.loggedIn) {
+      this.setState({showLogin: true});
+    } else {
+      let favoriteRecipeIds = this.state.favorites.map(element => element.id);
+      if (modify) {
+        if (favoriteRecipeIds.includes(recipeId)) {
+          axios.put(`${API_ADDR}/users/${this.state.user.id}/recipes/${recipeId}/remove`)
+          .then(res => {
+            this.setState({favorites: res.data.data});
+          })
+        } else {
+          axios.post(`${API_ADDR}/users/${this.state.user.id}/recipes/${recipeId}/add`)
+          .then(res => {
+            this.setState({favorites: res.data.data});
+          })
+        }
+  
+      } else {
+        return this.state.favorites;
+  
+        // // Uncomment when userId works
+        // axios.get(`${API_ADDR}/users/${this.state.user.userId}/recipes`)
+        // .then(res => {
+        //   this.setState({favorites: res.data});
+        // })
+      }
+    }
+
   }
 
   signUp(details) {
@@ -184,9 +183,15 @@ class App extends React.Component {
         that.setState({ user: {
           name: response.data.username,
           email: response.data.email,
-          id: response.data.userID
+          id: response.data.userID,
+          pantry: [],
+          usePantry: true
         }})
         console.log('this is document:', window)
+        axios.get(`${API_ADDR}/users/${that.state.user.id}/recipes`)
+          .then(res => {
+            that.setState({favorites: res.data});
+          })
       })
       .catch((error) => {
         console.error('user login error:', error);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,29 +74,6 @@ class App extends React.Component {
   }
 
   captureFavorites(recipeId = '', modify = false) {
-    // Tweak for fast favorites rendering
-    // let stringState = JSON.stringify(this.state.favorites);
-    // let stringRecipe = JSON.stringify(recipeId);
-
-    // if (modify) {
-    //   let action;
-    //   if (stringState.includes(stringRecipe)) {
-    //     action = 'remove';
-    //   } else {
-    //     action = 'add';
-    //   }
-    //   if (action === 'add') {
-    //     this.setState(prevState => ({favorites: [...JSON.parse(JSON.stringify(prevState.favorites)), recipeId]}), () => {
-    //     })
-    //   }
-
-    //   if (action === 'remove') {
-    //     this.setState(prevState => ({favorites: prevState.favorites.filter(recipe => JSON.stringify(recipe) !== JSON.stringify(recipeId))}))
-    //   }
-    // } else {
-    //   return this.state.favorites;
-    // }
-
     if (!this.state.loggedIn) {
       this.setState({showLogin: true});
     } else {
@@ -116,12 +93,6 @@ class App extends React.Component {
   
       } else {
         return this.state.favorites;
-  
-        // // Uncomment when userId works
-        // axios.get(`${API_ADDR}/users/${this.state.user.userId}/recipes`)
-        // .then(res => {
-        //   this.setState({favorites: res.data});
-        // })
       }
     }
 

--- a/src/components/RecipeTile.jsx
+++ b/src/components/RecipeTile.jsx
@@ -46,7 +46,6 @@ const RecipeTile = ({ captureNavigation, recipe, captureRecipeId, favorites, cap
           >
             {recipe.title.substring(0, 40)}{recipe.title.length > 40 ? '...' : ''}
           </div>}
-          {/* <img className="recipeTileFavoriteIcon" src={favorites.includes(recipe.id) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipe.id, true)} /> */}
           <img className="recipeTileFavoriteIcon" src={favoriteRecipeIds.includes(recipe.id) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipe.id, true)} />
         </div>
 

--- a/src/components/RecipeTile.jsx
+++ b/src/components/RecipeTile.jsx
@@ -11,6 +11,8 @@ const RecipeTile = ({ captureNavigation, recipe, captureRecipeId, favorites, cap
   const numberWithCommas = (x) => {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   }
+  let favoriteRecipeIds = favorites.map(element => element.id);
+
   return (
     <div className="recipeTileContainer">
       <img
@@ -45,7 +47,7 @@ const RecipeTile = ({ captureNavigation, recipe, captureRecipeId, favorites, cap
             {recipe.title.substring(0, 40)}{recipe.title.length > 40 ? '...' : ''}
           </div>}
           {/* <img className="recipeTileFavoriteIcon" src={favorites.includes(recipe.id) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipe.id, true)} /> */}
-          <img className="recipeTileFavoriteIcon" src={JSON.stringify(favorites).includes(JSON.stringify(recipe)) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipe, true)} />
+          <img className="recipeTileFavoriteIcon" src={favoriteRecipeIds.includes(recipe.id) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipe.id, true)} />
         </div>
 
         <div className="recipeTileStats">

--- a/src/components/SoloRecipeView.jsx
+++ b/src/components/SoloRecipeView.jsx
@@ -24,6 +24,8 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
   const numberWithCommas = (x) => {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   }
+  let favoriteRecipeIds = favorites.map(element => element.id);
+  
   useEffect(() => {
     getRecipe(recipeId);
   }, [recipeId])
@@ -37,12 +39,12 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
       <div className="recipeViewHeader">
         {window.innerWidth <= 800 && <div className="mobileBackFavorite">
           <img className="backButton" src={back} onClick={(e) => captureNavigation(previousView)}/>
-          <img className="favoriteButton" src={JSON.stringify(favorites).includes(JSON.stringify(recipe)) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipe, true)}/>
+          <img className="favoriteButton" src={favoriteRecipeIds.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/>
         </div>}
         {window.innerWidth > 800 && <img className="backButton" src={back} onClick={(e) => captureNavigation(previousView)}/>}
         <div className="recipeName">{recipe.title}</div>
         {/* <img className="favoriteButton" src={favorites.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/> */}
-        {window.innerWidth > 800 && <img className="favoriteButton" src={JSON.stringify(favorites).includes(JSON.stringify(recipe)) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipe, true)}/>}
+        {window.innerWidth > 800 && <img className="favoriteButton" src={favoriteRecipeIds.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/>}
       </div>
       <div className="recipeInformation">
         <img className="recipeImage" src={recipe.image}/>

--- a/src/components/SoloRecipeView.jsx
+++ b/src/components/SoloRecipeView.jsx
@@ -25,7 +25,7 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   }
   let favoriteRecipeIds = favorites.map(element => element.id);
-  
+
   useEffect(() => {
     getRecipe(recipeId);
   }, [recipeId])
@@ -43,7 +43,6 @@ const SoloRecipeView = ({ captureNavigation, recipeId, previousView, favorites, 
         </div>}
         {window.innerWidth > 800 && <img className="backButton" src={back} onClick={(e) => captureNavigation(previousView)}/>}
         <div className="recipeName">{recipe.title}</div>
-        {/* <img className="favoriteButton" src={favorites.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/> */}
         {window.innerWidth > 800 && <img className="favoriteButton" src={favoriteRecipeIds.includes(recipeId) ? fullStar : emptyStar} onClick={(e) => captureFavorites(recipeId, true)}/>}
       </div>
       <div className="recipeInformation">


### PR DESCRIPTION
@lbc1013 @Heine574 @winstonthep 

- Favorite functionality now available only to registered users.
- Attempting to favorite a recipe while not logged in will open the login/signup form
- After a user logs in, within the same login function, an additional call is made to the API to retrieve the user's favorite recipes and write them to the app state.
- Temporarily added pantry = [] and usePantry=true to the 'setState' that occurs after a user logs in. Before, user.pantry did not exist for a logged in user so it would break some functionality in other components. The pantry being embedded in the user field might be troublesome, because every time you want to change the pantry you have to ```this.setState(prevState => ({user: {name: prevState.user.name, email: prevState.user.email, id: prevState.user.id, pantry: pantry, usePantry: true}}))```. If I understand setState correctly, passing only pantry won't just update the pantry and leave the rest intact, it will completely replace whatever is in user with whatever you pass. I might be wrong, but components that used the pantry were breaking after signing in because pantry was missing from the user setState when signing in and adding the pantry in there fixed the problem.
- Ideally, after the user logs in, 2 more get requests should be made within the function: get the user's favorite recipes and the user's pantry, even if both are empty arrays.