### PR TITLE
fixed tile length on narrow browsers

### DIFF
--- a/dist/styles/HomeView.css
+++ b/dist/styles/HomeView.css
@@ -152,6 +152,12 @@
   background: rgba(128, 128, 128, 0.377);
 }
 
+@media only screen and (max-width: 1050px) {
+  #receipeBox {
+    width: 100%;
+  }
+}
+
 @media only screen and (max-device-width: 800px) {
   #homeTopView {
     margin-top: 0;


### PR DESCRIPTION
@lbc1013 @winstonthep @Heine574 

- Recipe Tiles now use the full window length when the browser width is less than 1050px